### PR TITLE
fix: only include listening ports in port checks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,13 +20,13 @@ if [ -f /.dockerenv ]; then
 fi
 
 # check if something is running on port 80
-if lsof -i :80 >/dev/null; then
+if lsof -i :80 -sTCP:LISTEN >/dev/null; then
     echo "Error: something is already running on port 80" >&2
     exit 1
 fi
 
 # check if something is running on port 443
-if lsof -i :443 >/dev/null; then
+if lsof -i :443 -sTCP:LISTEN >/dev/null; then
     echo "Error: something is already running on port 443" >&2
     exit 1
 fi


### PR DESCRIPTION
Updates the port checks to look for listening TCP ports only, instead of including outgoing connections which would cause the script to fail if there's any outgoing connections to ports 80 or 443